### PR TITLE
Adding ElMu and MuEl categories + bug fix

### DIFF
--- a/interface/ZADileptonCategories.h
+++ b/interface/ZADileptonCategories.h
@@ -150,7 +150,7 @@ class ElElCategory: public DileptonCategory {
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
 };
 
-/*
+
 
 class ElMuCategory: public DileptonCategory {
   public:
@@ -167,7 +167,7 @@ class ElMuCategory: public DileptonCategory {
     virtual void register_cuts(CutManager& manager) override;
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
 };
-*/
+
 
 class MuMuCategory: public DileptonCategory {
   public:

--- a/plugins/ZADileptonCategories.cc
+++ b/plugins/ZADileptonCategories.cc
@@ -243,7 +243,7 @@ void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
 
   if(za.diLeptons.size() >= 1) {
     const DiLepton& m_diLepton = za.diLeptons[0];
-
+    
     if(m_diLepton.isMuEl) {
       manager.pass_cut(baseStrCategory );
 

--- a/plugins/ZADileptonCategories.cc
+++ b/plugins/ZADileptonCategories.cc
@@ -192,3 +192,189 @@ void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
     }
   }
 }
+
+// ***** ***** *****
+// Dilepton Mu-El category
+// ***** ***** *****
+
+bool MuElCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
+  const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
+  const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
+  return muons.p4.size()>=1 &&   electrons.p4.size() >= 1;
+}
+
+bool MuElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+
+  const ZAAnalyzer& za = analyzers.get<ZAAnalyzer>("za");
+return true;
+}
+
+void MuElCategory::register_cuts(CutManager& manager) {
+
+
+    manager.new_cut(baseStrCategory, baseStrCategory);
+    manager.new_cut(baseStrMllCut, baseStrMllCut);
+    manager.new_cut(baseStrDiLeptonIsOS, baseStrDiLeptonIsOS);
+    manager.new_cut(baseStrDileptonIsIDMM, baseStrDileptonIsIDMM);
+    manager.new_cut(baseStrDileptonIsIDTT, baseStrDileptonIsIDTT);
+    manager.new_cut(baseStrDileptonIsoLL, baseStrDileptonIsoLL);
+    manager.new_cut(baseStrLooseZCandidate, baseStrLooseZCandidate);
+    manager.new_cut(baseStrTightZCandidate, baseStrTightZCandidate);
+    manager.new_cut(baseStrDiJetBWP_ML, baseStrDiJetBWP_ML);
+    manager.new_cut(baseStrDiJetBWP_MM, baseStrDiJetBWP_MM);
+    manager.new_cut(baseStrDiJetBWP_TM, baseStrDiJetBWP_TM);
+    manager.new_cut(baseStrOneJet,baseStrOneJet);
+    manager.new_cut(baseStrTwoJets,baseStrTwoJets);
+    manager.new_cut(baseStrTwoJetsExcl,baseStrTwoJetsExcl);
+    manager.new_cut(baseStrOneBjet,baseStrOneBjet);
+    manager.new_cut(baseStrTwoBjets,baseStrTwoBjets);
+    manager.new_cut(baseStrTwoBjetsExcl,baseStrTwoBjetsExcl);
+    manager.new_cut(baseStrThreeJets,baseStrThreeJets);
+    manager.new_cut(baseStrThreeBjets,baseStrThreeBjets);
+
+
+}
+
+void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+
+  const ZAAnalyzer& za = analyzers.get<ZAAnalyzer>("za");
+  const HLTProducer& hlt = producers.get<HLTProducer>("hlt");
+
+
+  if(za.diLeptons.size() >= 1) {
+    const DiLepton& m_diLepton = za.diLeptons[0];
+
+    if(m_diLepton.isMuEl) {
+      manager.pass_cut(baseStrCategory );
+
+      if(m_diLepton.p4.M() > m_MllCutSF)
+        manager.pass_cut(baseStrMllCut);
+
+      if(m_diLepton.isMM) manager.pass_cut(baseStrDileptonIsIDMM);
+      if(m_diLepton.isTT) manager.pass_cut(baseStrDileptonIsIDTT);
+      if(m_diLepton.isIsoLL) manager.pass_cut(baseStrDileptonIsoLL);
+
+      if(m_diLepton.isOS)
+      {
+        manager.pass_cut(baseStrDiLeptonIsOS);
+        if (m_diLepton.p4.M() > m_lowLooseZcut  && m_diLepton.p4.M() < m_highLooseZcut )
+        {
+          manager.pass_cut(baseStrLooseZCandidate);
+          if (m_diLepton.p4.M() > m_lowTightZcut  && m_diLepton.p4.M() < m_highTightZcut )
+            manager.pass_cut(baseStrTightZCandidate);
+        }
+      }
+      if (za.selJets.size() >= 1) manager.pass_cut(baseStrOneJet);
+      if (za.selJets.size() >= 2) manager.pass_cut(baseStrTwoJets);
+      if (za.selJets.size() == 2) manager.pass_cut(baseStrTwoJetsExcl);
+      if (za.selJets.size() >= 3) manager.pass_cut(baseStrThreeJets);
+
+      if (za.selBjetsM.size() >= 1) manager.pass_cut(baseStrOneBjet);
+      if (za.selBjetsM.size() >= 2) manager.pass_cut(baseStrTwoBjets);
+      if (za.selBjetsM.size() == 2) manager.pass_cut(baseStrTwoBjetsExcl);
+      if (za.selBjetsM.size() >= 3) manager.pass_cut(baseStrThreeBjets);
+
+      if (za.diJets.size() >= 1) {
+        const DiJet& m_diJet = za.diJets[0];
+        if (m_diJet.isML) manager.pass_cut(baseStrDiJetBWP_ML);
+        if (m_diJet.isMM) manager.pass_cut(baseStrDiJetBWP_MM);
+        if (m_diJet.isTM) manager.pass_cut(baseStrDiJetBWP_TM);
+      }
+    }
+  }
+}
+
+
+
+
+
+
+bool ElMuCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
+  const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
+  const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
+  return muons.p4.size()>=1 &&   electrons.p4.size() >= 1;
+}
+
+bool ElMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+
+  const ZAAnalyzer& za = analyzers.get<ZAAnalyzer>("za");
+return true;
+}
+
+void ElMuCategory::register_cuts(CutManager& manager) {
+
+
+    manager.new_cut(baseStrCategory, baseStrCategory);
+    manager.new_cut(baseStrMllCut, baseStrMllCut);
+    manager.new_cut(baseStrDiLeptonIsOS, baseStrDiLeptonIsOS);
+    manager.new_cut(baseStrDileptonIsIDMM, baseStrDileptonIsIDMM);
+    manager.new_cut(baseStrDileptonIsIDTT, baseStrDileptonIsIDTT);
+    manager.new_cut(baseStrDileptonIsoLL, baseStrDileptonIsoLL);
+    manager.new_cut(baseStrLooseZCandidate, baseStrLooseZCandidate);
+    manager.new_cut(baseStrTightZCandidate, baseStrTightZCandidate);
+    manager.new_cut(baseStrDiJetBWP_ML, baseStrDiJetBWP_ML);
+    manager.new_cut(baseStrDiJetBWP_MM, baseStrDiJetBWP_MM);
+    manager.new_cut(baseStrDiJetBWP_TM, baseStrDiJetBWP_TM);
+    manager.new_cut(baseStrOneJet,baseStrOneJet);
+    manager.new_cut(baseStrTwoJets,baseStrTwoJets);
+    manager.new_cut(baseStrTwoJetsExcl,baseStrTwoJetsExcl);
+    manager.new_cut(baseStrOneBjet,baseStrOneBjet);
+    manager.new_cut(baseStrTwoBjets,baseStrTwoBjets);
+    manager.new_cut(baseStrTwoBjetsExcl,baseStrTwoBjetsExcl);
+    manager.new_cut(baseStrThreeJets,baseStrThreeJets);
+    manager.new_cut(baseStrThreeBjets,baseStrThreeBjets);
+
+
+}
+
+void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+
+  const ZAAnalyzer& za = analyzers.get<ZAAnalyzer>("za");
+  const HLTProducer& hlt = producers.get<HLTProducer>("hlt");
+
+
+  if(za.diLeptons.size() >= 1) {
+    const DiLepton& m_diLepton = za.diLeptons[0];
+
+    if(m_diLepton.isElMu) {
+      manager.pass_cut(baseStrCategory );
+
+      if(m_diLepton.p4.M() > m_MllCutSF)
+        manager.pass_cut(baseStrMllCut);
+
+      if(m_diLepton.isMM) manager.pass_cut(baseStrDileptonIsIDMM);
+      if(m_diLepton.isTT) manager.pass_cut(baseStrDileptonIsIDTT);
+      if(m_diLepton.isIsoLL) manager.pass_cut(baseStrDileptonIsoLL);
+
+      if(m_diLepton.isOS)
+      {
+        manager.pass_cut(baseStrDiLeptonIsOS);
+        if (m_diLepton.p4.M() > m_lowLooseZcut  && m_diLepton.p4.M() < m_highLooseZcut )
+        {
+          manager.pass_cut(baseStrLooseZCandidate);
+          if (m_diLepton.p4.M() > m_lowTightZcut  && m_diLepton.p4.M() < m_highTightZcut )
+            manager.pass_cut(baseStrTightZCandidate);
+        }
+      }
+      if (za.selJets.size() >= 1) manager.pass_cut(baseStrOneJet);
+      if (za.selJets.size() >= 2) manager.pass_cut(baseStrTwoJets);
+      if (za.selJets.size() == 2) manager.pass_cut(baseStrTwoJetsExcl);
+      if (za.selJets.size() >= 3) manager.pass_cut(baseStrThreeJets);
+
+      if (za.selBjetsM.size() >= 1) manager.pass_cut(baseStrOneBjet);
+      if (za.selBjetsM.size() >= 2) manager.pass_cut(baseStrTwoBjets);
+      if (za.selBjetsM.size() == 2) manager.pass_cut(baseStrTwoBjetsExcl);
+      if (za.selBjetsM.size() >= 3) manager.pass_cut(baseStrThreeBjets);
+
+      if (za.diJets.size() >= 1) {
+        const DiJet& m_diJet = za.diJets[0];
+        if (m_diJet.isML) manager.pass_cut(baseStrDiJetBWP_ML);
+        if (m_diJet.isMM) manager.pass_cut(baseStrDiJetBWP_MM);
+        if (m_diJet.isTM) manager.pass_cut(baseStrDiJetBWP_TM);
+      }
+    }
+  }
+}
+
+
+

--- a/plugins/ZASimpleAnalyser.cc
+++ b/plugins/ZASimpleAnalyser.cc
@@ -379,8 +379,8 @@ void ZAAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup, 
 
 void ZAAnalyzer::registerCategories(CategoryManager& manager, const edm::ParameterSet& config) {
   manager.new_category<ZAAnalysis::ElElCategory>("elel", "Category with leading leptons as two electrons", config);
-  // manager.new_category<TTAnalysis::ElMuCategory>("elmu", "Category with leading leptons as electron, muon", config);
-  //manager.new_category<TTAnalysis::MuElCategory>("muel", "Category with leading leptons as muon, electron", config);
+  manager.new_category<ZAAnalysis::ElMuCategory>("elmu", "Category with leading leptons as electron, muon", config);
+  manager.new_category<ZAAnalysis::MuElCategory>("muel", "Category with leading leptons as muon, electron", config);
   manager.new_category<ZAAnalysis::MuMuCategory>("mumu", "Category with leading leptons as two muons", config);
 }
 

--- a/plugins/ZASimpleAnalyser.cc
+++ b/plugins/ZASimpleAnalyser.cc
@@ -108,7 +108,6 @@ void ZAAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup, 
       {
           isolatedMuons.push_back(m_lepton);
           leptons.push_back(m_lepton);
-
       }
       // if muon good enough for veto, adding to the collection vetoLepton
       else if (muons.isLoose[imuon])
@@ -279,7 +278,6 @@ void ZAAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup, 
     const Lepton& l1 = leptons[0];
     const Lepton& l2 = leptons[1];
 
-
     if (l1.p4.Pt() > l2.p4.Pt())
       {
       dilep_ptOrdered.push_back(l1);
@@ -294,10 +292,10 @@ void ZAAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup, 
     DiLepton m_diLepton(l1, l2);
 
     //m_diLepton.p4 = l1.p4 + l2.p4;
-    m_diLepton.isElEl = l1.isEl && l2.isEl;
-    m_diLepton.isElMu = l1.isEl && l2.isMu;
-    m_diLepton.isMuEl = l1.isMu && l2.isEl;
-    m_diLepton.isMuMu = l1.isMu && l2.isMu;
+    m_diLepton.isElEl = dilep_ptOrdered[0].isEl && dilep_ptOrdered[1].isEl;
+    m_diLepton.isElMu = dilep_ptOrdered[0].isEl && dilep_ptOrdered[1].isMu;
+    m_diLepton.isMuEl = dilep_ptOrdered[0].isMu && dilep_ptOrdered[1].isEl;
+    m_diLepton.isMuMu = dilep_ptOrdered[0].isMu && dilep_ptOrdered[1].isMu;
     m_diLepton.isOS = l1.charge != l2.charge;
     m_diLepton.isSF = m_diLepton.isElEl || m_diLepton.isMuMu;
 


### PR DESCRIPTION
This PR refers to the inclusion/revival of ElMu and MuEl categories to ZAAnalysis, in order e.g. to get to the ttbar control region. It also fixes a bug to set the values of the bools 'isElMu' and 'isMuEl': the bug is that the ordering was dependent only on the position of the loop on the electrons and muons in the code: electron was always first=> no isMuEl event. Now it is pt-ordered. 
