### PR TITLE
add mva Id for electrons

### DIFF
--- a/interface/HtoZAAnalyzer.h
+++ b/interface/HtoZAAnalyzer.h
@@ -42,6 +42,9 @@ class HtoZAAnalyzer: public Framework::Analyzer {
             m_electron_medium_wp_name = config.getUntrackedParameter<std::string>("electrons_medium_wp_name");
             m_electron_tight_wp_name = config.getUntrackedParameter<std::string>("electrons_tight_wp_name");
             m_electron_hlt_safe_wp_name = config.getUntrackedParameter<std::string>("electrons_hlt_safe_wp_name");
+            m_electron_mva_wp80_name = config.getUntrackedParameter<std::string>("electrons_mva_wp80_name");
+            m_electron_mva_wp90_name = config.getUntrackedParameter<std::string>("electrons_mva_wp80_name");
+            m_electron_mva_HZZ_loose_wp_name = config.getUntrackedParameter<std::string>("electrons_mva_HZZ_loose_wp_name");
 
             m_jetEtaCut = config.getUntrackedParameter<double>("jetEtaCut", 2.4);
             m_jetPtCut = config.getUntrackedParameter<double>("jetPtCut", 20);
@@ -259,6 +262,9 @@ class HtoZAAnalyzer: public Framework::Analyzer {
         std::string m_electron_medium_wp_name;
         std::string m_electron_tight_wp_name;
         std::string m_electron_hlt_safe_wp_name;
+        std::string m_electron_mva_wp80_name;
+        std::string m_electron_mva_wp90_name;
+        std::string m_electron_mva_HZZ_loose_wp_name;
         bool m_applyBJetRegression;
         std::unordered_map<std::string, std::unique_ptr<BinnedValues>> m_hlt_efficiencies;
 

--- a/plugins/HtoZAAnalyzer.cc
+++ b/plugins/HtoZAAnalyzer.cc
@@ -307,13 +307,15 @@ void HtoZAAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, con
         
         bool result = allelectrons.ids[index][m_electron_hlt_safe_wp_name];
 
-        // Add dxy and dz cuts described at https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Offline_selection_criteria
+        // Add dxy and dz cuts described at https://github.com/latinos/LatinoAnalysis/blob/master/Gardener/python/variables/LeptonSel_cfg.py 
         if (electron->isEB()) {
             result &= std::abs(allelectrons.dz[index]) < 0.1;
             result &= std::abs(allelectrons.dxy[index]) < 0.05;
+            result &= std::abs(allelectrons.relativeIsoR04_withEA[index]) < 0.05880;
         } else {
             result &= std::abs(allelectrons.dz[index]) < 0.2;
             result &= std::abs(allelectrons.dxy[index]) < 0.1;
+            result &= std::abs(allelectrons.relativeIsoR04_withEA[index]) < 0.0571;
         }
 
         return result;
@@ -328,7 +330,7 @@ void HtoZAAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, con
         {
             // some selection
             // Ask for medium ID
-            if (!allelectrons.ids[ielectron][m_electron_medium_wp_name])
+            if (!allelectrons.ids[ielectron][m_electron_mva_wp90_name])
                 continue;
 
             HtoZA::Lepton ele;

--- a/plugins/HtoZAAnalyzer.cc
+++ b/plugins/HtoZAAnalyzer.cc
@@ -307,7 +307,7 @@ void HtoZAAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, con
         
         bool result = allelectrons.ids[index][m_electron_hlt_safe_wp_name];
 
-        // Add dxy and dz cuts described at https://github.com/latinos/LatinoAnalysis/blob/master/Gardener/python/variables/LeptonSel_cfg.py 
+        // Add dxy and dz cuts described at https://github.com/latinos/LatinoAnalysis/blob/de026c531cec33d6f1cb999ec720e52692596116/Gardener/python/variables/LeptonSel_cfg.py
         if (electron->isEB()) {
             result &= std::abs(allelectrons.dz[index]) < 0.1;
             result &= std::abs(allelectrons.dxy[index]) < 0.05;
@@ -329,7 +329,7 @@ void HtoZAAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, con
         if (allelectrons.p4[ielectron].Pt() > m_subleadingElectronPtCut && fabs(allelectrons.p4[ielectron].Eta()) < m_electronEtaCut)
         {
             // some selection
-            // Ask for medium ID
+            // Ask for loose ID
             if (!allelectrons.ids[ielectron][m_electron_mva_wp90_name])
                 continue;
 

--- a/test/HtoZAConfiguration.py
+++ b/test/HtoZAConfiguration.py
@@ -129,7 +129,6 @@ else:
 
             # Signal: H->ZA - mH=500, mA=100
             '/store/mc/RunIISummer16MiniAODv2/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/9475A8FB-25DF-E611-AFA8-20CF3019DF02.root'
-            # '/store/mc/RunIISpring16MiniAODv2/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/20000/1287F415-023B-E611-A374-FA163E48F4D0.root'
 
             # Background: TT
             # '/store/mc/RunIISummer16MiniAODv2/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/00ED79D3-CFC1-E611-B748-3417EBE64483.root'

--- a/test/HtoZAConfiguration.py
+++ b/test/HtoZAConfiguration.py
@@ -125,10 +125,11 @@ else:
     process.source.fileNames = cms.untracked.vstring(
 	    
             # Signal: H->ZA - mH=1000, mA=200
-            # '/store/mc/RunIISpring16MiniAODv2/HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/80000/12283330-9F3A-E611-9513-0025907B4F30.root'
+            # '/store/mc/RunIISummer16MiniAODv2/HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/100000/A2BC660D-17DD-E611-9B31-001517F7F950.root'
 
             # Signal: H->ZA - mH=500, mA=100
-            '/store/mc/RunIISpring16MiniAODv2/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/20000/1287F415-023B-E611-A374-FA163E48F4D0.root'
+            '/store/mc/RunIISummer16MiniAODv2/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/9475A8FB-25DF-E611-AFA8-20CF3019DF02.root'
+            # '/store/mc/RunIISpring16MiniAODv2/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/20000/1287F415-023B-E611-A374-FA163E48F4D0.root'
 
             # Background: TT
             # '/store/mc/RunIISummer16MiniAODv2/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/00ED79D3-CFC1-E611-B748-3417EBE64483.root'

--- a/test/HtoZAConfiguration.py
+++ b/test/HtoZAConfiguration.py
@@ -57,12 +57,16 @@ framework.addAnalyzer('hZA_analyzer', cms.PSet(
             electrons_medium_wp_name = cms.untracked.string("cutBasedElectronID-Summer16-80X-V1-medium"),
             electrons_tight_wp_name = cms.untracked.string("cutBasedElectronID-Summer16-80X-V1-tight"),
             electrons_hlt_safe_wp_name = cms.untracked.string("cutBasedElectronHLTPreselection-Summer16-V1"),
+            electrons_mva_wp80_name = cms.untracked.string("mvaEleID-Spring16-GeneralPurpose-V1-wp80"),
+            electrons_mva_wp90_name = cms.untracked.string("mvaEleID-Spring16-GeneralPurpose-V1-wp90"),
+            electrons_mva_HZZ_loose_wp_name = cms.untracked.string("mvaEleID-Spring16-HZZ-V1-wpLoose"),
+            
             jetEtaCut = cms.untracked.double(2.4),
             jetPtCut = cms.untracked.double(20),
 
             # BTAG INFO
             # Working points from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation80XReReco
-            discr_name =  cms.untracked.string("pfCombinedMVAV2BJetTags"),
+            discr_name = cms.untracked.string("pfCombinedMVAV2BJetTags"),
             discr_cut_loose =  cms.untracked.double(-0.5884),
             discr_cut_medium =  cms.untracked.double(0.4432),
             discr_cut_tight =  cms.untracked.double(0.9432),
@@ -97,8 +101,6 @@ framework.getProducer('hlt').parameters.triggers = cms.untracked.FileInPath('cp3
 # framework.getProducer('jets').parameters.cut = cms.untracked.string("pt > 20")
 #framework.getProducer('jets').parameters.computeRegression = cms.untracked.bool(True)
 
-framework.getProducer('electrons').parameters.scale_factors.id_mediumplushltsafe_hh = cms.untracked.FileInPath('cp3_llbb/ZAAnalysis/data/ScaleFactors/Electron_MediumPlusHLTSafeID_moriond17.json')
-
 if runOnData:
     framework.redoJEC()
 
@@ -121,19 +123,17 @@ else:
     process.framework.treeFlushSize = cms.untracked.uint64(5 * 1024 * 1024)
 
     process.source.fileNames = cms.untracked.vstring(
-            # Signal
-            #'/store/mc/RunIISummer16MiniAODv2/GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph-v2/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/60000/2E1015E2-71D9-E611-911E-02163E019E19.root'
 	    
             # Signal: H->ZA - mH=1000, mA=200
-	        #'/store/mc/RunIISpring16MiniAODv2/HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/80000/12283330-9F3A-E611-9513-0025907B4F30.root'
+            # '/store/mc/RunIISpring16MiniAODv2/HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/80000/12283330-9F3A-E611-9513-0025907B4F30.root'
 
             # Signal: H->ZA - mH=500, mA=100
             '/store/mc/RunIISpring16MiniAODv2/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/20000/1287F415-023B-E611-A374-FA163E48F4D0.root'
 
-            # TT
+            # Background: TT
             # '/store/mc/RunIISummer16MiniAODv2/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/00ED79D3-CFC1-E611-B748-3417EBE64483.root'
 
-            # DY
+            # Background: DY
             # '/store/mc/RunIISummer16MiniAODv2/DYToLL_2J_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/100000/00CEFB4F-C1D2-E611-BBF4-7845C4FC3C11.root<Paste>'
         )
 


### PR DESCRIPTION
1) The Iso variable specified at https://github.com/latinos/LatinoAnalysis/blob/de026c531cec33d6f1cb999ec720e52692596116/Gardener/python/variables/LeptonSel_cfg.py is 'relPFIsoRhoCorr'. The one that I used (from the FW) is 'relativeIsoR04_withEA', although I didn't find any info whether the 'relPFIsoRhoCorr' implies a cone of 0.4 or 0.3 (in the latter case I should have used 'relativeIsoR03_withEA'). Any idea on how to get this info?

2) As discussed yesterday with @OlivierBondu, I'm selecting electrons with 'mvaEleID-Spring16-GeneralPurpose-V1-wp90'. Any comment/remark?

3) Should I completely remove the ICHEP'16 IDs?